### PR TITLE
Update list of rafalab members

### DIFF
--- a/pages/people.md
+++ b/pages/people.md
@@ -15,6 +15,7 @@ title: people
 - [Matthew Ploenzke](https://mploenzke.github.io/) (Graduate Student)
 - Samuela Pollack (Software Engineer)
 - [Alejandro Reyes](http://alejandroreyes.org/) (Postdoc)
+- [Kelly Street](https://github.com/kstreet13/) (Postdoc)
 - [Will Townes](https://willtownes.github.io/) (Graduate Student)
 
 #### Past Postdocs

--- a/pages/people.md
+++ b/pages/people.md
@@ -49,7 +49,7 @@ title: people
 #### FFOL (Former Friends of the Lab)
 
 - Joseph N. Paulson (Genentech)
-- [Claire Duvallet](https://cduvallet.github.io/) (FOL = Friend of the Lab)
+- [Claire Duvallet](https://cduvallet.github.io/) (Biobot Analytics)
 
 #### Past Visitors 
 

--- a/pages/people.md
+++ b/pages/people.md
@@ -49,7 +49,7 @@ title: people
 #### FFOL (Former Friends of the Lab)
 
 - Joseph N. Paulson (Genentech)
-- [Claire Duvallet](https://cduvallet.github.io/) (Biobot Analytics)
+- [Claire Duvallet](https://cduvallet.github.io/)
 
 #### Past Visitors 
 

--- a/pages/people.md
+++ b/pages/people.md
@@ -6,7 +6,6 @@ title: people
 #### Current Lab Members
 
 - Rolando Acosta (Graduate Student)
-- [Claire Duvallet](https://cduvallet.github.io/) (FOL = Friend of the Lab)
 - Linglin Huang (Graduate Student)
 - Rafael Irizarry (Principal Investigator)
 - [Patrick Kimes](http://pkimes.org/) (Postdoc)
@@ -38,7 +37,7 @@ title: people
 #### PhD Alumni
 
 - [Zhijin Wu](http://www.stat.brown.edu/zwu/) 2005 (Brown University, Associate Professor)
-- Benilton Carvalho 2008 (Universidade Estadual de Campinas, Assistant Professor)
+- [Benilton Carvalho](https://scholar.google.com/citations?hl=es&user=44vQTS4AAAAJ) 2008 (Universidade Estadual de Campinas, Assistant Professor)
 - [Matthew McCall](https://mnmccall.com/) 2010 (University of Rochester, Assistant Professor)
 - [Hao Wu](http://www.haowulab.org/) 2010 (Emory University, Associate Professor)
 - [Samara Kiihl](https://samarafk.github.io/) 2013 (Universidade Estadual de Campinas, Assistant Professor)
@@ -47,15 +46,19 @@ title: people
 - Chinmay Shukla 2018 (True Fit)
 
 #### FFOL (Former Friends of the Lab)
+
 - Joseph N. Paulson (Genentech)
+- [Claire Duvallet](https://cduvallet.github.io/) (FOL = Friend of the Lab)
 
 #### Past Visitors 
+
 - Ana Ciconelle
 - Lieven Clement
 - Julia Engelmann
 - Matt Ritchie
 
 #### Summer Students
+
 - 2014: Esther Fervrier, Markus Havell, and  Savion Smith 
 - 2015: Pedro Mu&ntilde;oz Agrinsoni, Kevin Kupiec, and Randy Williams 
 - 2016: Alejandra DeJesús-Soto, Mark Ruprecht and Patricia Vera-González


### PR DESCRIPTION
1. Added @kstreet13 to "Current Lab Members". 
2. Based on an unanimous vote during yesterday's happy hour (voters: @pkimes, @kdkorthauer, @cshukla, @kstreet13 and @areyesq89), Dr. @cduvallet was given the "FFOL" title.